### PR TITLE
Shortcut to redraw if siblings fail to match

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -627,7 +627,10 @@ function diffHelp(a, b, patches, index)
 		case 'node':
 			// Bail if obvious indicators have changed. Implies more serious
 			// structural changes such that it's not worth it to diff.
-			if (a.tag !== b.tag || a.namespace !== b.namespace)
+			var hasSiblingChanges =
+				(directDescendantsCount(a) !== directDescendantsCount(b) && a.children.length !== b.children.length);
+
+			if (a.tag !== b.tag || a.namespace !== b.namespace || hasSiblingChanges)
 			{
 				patches.push(makePatch('p-redraw', index, b));
 				return;
@@ -758,6 +761,21 @@ function diffFacts(a, b, category)
 	}
 
 	return diff;
+}
+
+/*
+Get the sum of descendents directly below a node
+*/
+function directDescendantsCount(parentNode){
+	var num = 0;
+
+	parentNode.children.forEach(function(childNode){
+		if (childNode.type === 'node'){
+			num += childNode.children.length;
+		}
+	});
+
+	return num;
 }
 
 


### PR DESCRIPTION
## Problem 

- @lukewestby found [this](https://gist.github.com/lukewestby/3dc48266b15a4837a79ddd71e58c6999) bug, where a given node will attach event listeners to siblings sometimes, if the new nodes are prepending an existing node
- The problem is because when an element is inserted before a sibling, it applies the event facts to it again, and then inserts the correct thing

## Solution

- check if sibling counts fail to match, triggering a localized redraw

## Other notes

- It's possible that this is not the most performant way. I guess insertBefore might be something to add to resolve this truely. However, if there's only a bit of time before releasing 0.17, I think this fix is fine and a speed release can be done after.