### PR TITLE
Use DocumentFragment for patch insert

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -952,10 +952,12 @@ function applyPatch(domNode, patch)
 
 		case 'p-insert':
 			var newNodes = patch.data;
+			var fragment = document.createDocumentFragment();
 			for (var i = 0; i < newNodes.length; i++)
 			{
-				domNode.appendChild(render(newNodes[i], patch.eventNode));
+				fragment.appendChild(render(newNodes[i], patch.eventNode));
 			}
+			domNode.appendChild(fragment);
 			return domNode;
 
 		case 'p-custom':


### PR DESCRIPTION
[MDN recommends](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment) using `DocumentFragment` when appending multiple children to an element that's already mounted on the DOM, in order to avoid reflows.

I tried to find benchmarks to support or refute these, but they all seem to be pretty out of date. (In theory, if you aren't doing anything else in between the `appendChild` calls, the browser should be able to figure out that no reflow is necessary/appropriate. Not sure if that's true in practice though.)

Since benchmarking is happening anyway, I figured I'd throw this in there in case it might be faster.