### PR TITLE
Fixed deep equality bug for event options

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -251,9 +251,9 @@ function on(name, options, decoder)
 
 function equalEvents(a, b)
 {
-	if (!a.options === b.options)
+	if (a.options !== b.options)
 	{
-		if (a.stopPropagation !== b.stopPropagation || a.preventDefault !== b.preventDefault)
+		if (a.options.stopPropagation !== b.options.stopPropagation || a.options.preventDefault !== b.options.preventDefault)
 		{
 			return false;
 		}


### PR DESCRIPTION
The first condition was always false, and the second one lacked the `options` key.
