### PR TITLE
0.18 alpha: refer to value, not v, inside date to stringing

### DIFF
--- a/src/Native/Debug.js
+++ b/src/Native/Debug.js
@@ -139,7 +139,7 @@ function init(value)
 
 	if (value instanceof Date)
 	{
-		return '<' + v.toString() + '>';
+		return '<' + value.toString() + '>';
 	}
 
 	if (type === 'object' && 'ctor' in value)


### PR DESCRIPTION
# Problem

From https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/elm-dev/LZslB1keLhE/u0Faw3PwAwAJ


tl;dr when trying to use a date inside debugging mode, an error is thrown as `v` is undefined

TODO: the code to reproduce is incoming

# Solution

- `v` should've been `value`
- I checked for any other mismatches, and it looks good to me

# Thoughts

💭  maybe `v` should be replaced with `value` in Utils `toString` too, to keep them in sync?
