### PR TITLE
Changing way styles are applied to allow for custom properties

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -408,7 +408,7 @@ function applyStyles(domNode, styles)
 
 	for (var key in styles)
 	{
-		domNodeStyle[key] = styles[key];
+		domNodeStyle.setProperty(key, styles[key]);
 	}
 }
 


### PR DESCRIPTION
This PR changes the way that styles are applied to DOM nodes, in order to allow for setting CSS custom properties: https://www.w3.org/TR/css-variables-1/

``` diff
function applyStyles(domNode, styles)
{
  var domNodeStyle = domNode.style;

  for (var key in styles)
  {
-   domNodeStyle.style[key] = styles[key];
+   domNodeStyle.setProperty(key, styles[key]);
  }
}
```

This will allow developers to apply custom props in their styles like so:

``` elm
myStyle =
  style
    [ ("width", "100%")
    , ("height", "40px")
    , ("--my-color", "green")
    ]
```

without the custom property being ignored (which is the current behavior).
