### PR TITLE
fix bug in equalEvents

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -260,9 +260,9 @@ function on(name, options, decoder)
 
 function equalEvents(a, b)
 {
-	if (!a.options === b.options)
+	if (a.options !== b.options)
 	{
-		if (a.stopPropagation !== b.stopPropagation || a.preventDefault !== b.preventDefault)
+		if (a.options.stopPropagation !== b.options.stopPropagation || a.options.preventDefault !== b.options.preventDefault)
 		{
 			return false;
 		}


### PR DESCRIPTION
I'm writing another custom renderer this week to see what it takes to get an entire elm program to run in a web worker, and I happened across this bug in virtual-dom while copying its implementation.

Take this simple example program:

```elm
import Html exposing (..)
import Html.Events exposing (..)
import Json.Decode as Decode

type Msg
  = Increment
  | Decrement


update msg model =
  case msg of
    Increment ->
      model + 1
    
    Decrement ->
      model - 1


view model =
  let
    preventDefault =
      model % 2 == 0
  in
    div []
      [ button [ onClick Increment ] [ text "+" ]
      , text (toString model)
      , button
        [ onWithOptions "click" { defaultOptions | preventDefault = preventDefault } (Decode.succeed Decrement)
        ]
        [ text "-" ]
      ]

main =
  beginnerProgram
    { view = view
    , model = 0
    , update = update
    }
```

In this program every change in the counter should cause a change in the options for the previous virtual tree's representation of the decrement click handler. What is expected is that the current implementation should detect that the options have changed by reference, pick up the change in `preventDefault`, and then return false. But it always skips to compare decoders, which _are_ equal and the change in options never propagates to the real DOM.

The reason for this are twofold:

- `!a.options === b.options` is not the correct way to compare the options, `!` takes precedence over `===` so it's always being coerced to a boolean and then that boolean is being compared to an object so the result is always `false`. As another example of this, `!'hello' === 'hello'` returns `false`, but so does `!'hello' === 'hi'`.
- `a.stopPropagation !== b.stopPropagation ...` should be `a.options.stopPropagation ...`, just a simple typo.

This PR corrects those two issues and everything works fine.

Thanks!