### PR TITLE
Resizable debugger sidebar

### DIFF
--- a/src/VirtualDom/Debug.elm
+++ b/src/VirtualDom/Debug.elm
@@ -476,9 +476,7 @@ body {
 
 #values {
   display: block;
-  float: left;
   height: 100%;
-  width: calc(100% - 30ch);
   margin: 0;
   overflow: auto;
   cursor: default;

--- a/src/VirtualDom/Debug.elm
+++ b/src/VirtualDom/Debug.elm
@@ -491,6 +491,8 @@ body {
   height: 100%;
   color: white;
   background-color: rgb(61, 61, 61);
+  overflow-x: auto;
+  resize: horizontal;
 }
 
 .debugger-sidebar-controls {

--- a/src/VirtualDom/History.elm
+++ b/src/VirtualDom/History.elm
@@ -277,11 +277,14 @@ viewMessage currentIndex index msg =
 
       else
         "messages-entry"
+
+    messageName =
+      Native.Debug.messageToString msg
   in
     VDom.div
       [ VDom.class className
       , VDom.on "click" (Decode.succeed index)
       ]
-      [ VDom.span [VDom.class "messages-entry-content"] [ VDom.text (Native.Debug.messageToString msg) ]
+      [ VDom.span [VDom.class "messages-entry-content", VDom.title messageName ] [ VDom.text messageName ]
       , VDom.span [VDom.class "messages-entry-index"] [ VDom.text (toString index) ]
       ]


### PR DESCRIPTION
This addresses [the reported issue](https://groups.google.com/d/msg/elm-dev/K1-P4I9TyBE/oMu10xF8AwAJ) with long messages becoming unreadable. It does two things:

1. Add a `title` to each of the messages, so if it's truncated you can hover over it to see more.
2. Add `resize:horizontal` to the sidebar, so you can drag-to-resize it like a `textarea`.

![debugger-demo](https://cloud.githubusercontent.com/assets/1094080/20023943/767b3404-a2a0-11e6-87ec-654a348d42b6.gif)
