### PR TITLE
Handle contenteditable element removal issue.

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -857,6 +857,13 @@ function diffChildren(aParent, bParent, patches, rootIndex)
 		patches.push(makePatch('p-append', rootIndex, bChildren.slice(aLen)));
 	}
 
+    
+    var comparingContentEditable = false;
+    if (('contentEditable' in aParent.facts) || ('contentEditable' in bParent.facts))
+    {
+        comparingContentEditable = true;
+    }
+    
 	// PAIRWISE DIFF EVERYTHING ELSE
 
 	var index = rootIndex;
@@ -870,24 +877,29 @@ function diffChildren(aParent, bParent, patches, rootIndex)
         // The following checks on the `text` type elements address issue:
         //   https://github.com/elm-lang/virtual-dom/issues/48
         //
-        if (aChild.type == "text" && bChild.type == "text"){
-            if (aChild.text == "" && bChild.text == ""){
+        if (comparingContentEditable && (aChild.type == 'text' && bChild.type == 'text'))
+        {
+            if (aChild.text == '' && bChild.text == '')
+            {
                 // Do nothing so that the browser does not remove the cursor
                 // from the element if its a contenteditable element.
             }
-            else if (aChild.text == "" || bChild.text == ""){
+            else if (aChild.text == '' || bChild.text == '')
+            {
                 // We need to redraw the parent instead of trying to replace
                 // the value of the text element, because Chrome removes
                 // this element entirely once its value is an empty string.
                 patches.push(makePatch('p-redraw', rootIndex, bParent));
             }
-            else {
+            else
+            {
                 // Both elements have an actual text value so we'll proceed with
                 // the normal `text` patch.
                 diffHelp(aChild, bChild, patches, index);
             }
         }
-        else {
+        else
+        {
             diffHelp(aChild, bChild, patches, index);
         }
 

--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -865,7 +865,32 @@ function diffChildren(aParent, bParent, patches, rootIndex)
 	{
 		index++;
 		var aChild = aChildren[i];
-		diffHelp(aChild, bChildren[i], patches, index);
+		var bChild = bChildren[i];
+
+        // The following checks on the `text` type elements address issue:
+        //   https://github.com/elm-lang/virtual-dom/issues/48
+        //
+        if (aChild.type == "text" && bChild.type == "text"){
+            if (aChild.text == "" && bChild.text == ""){
+                // Do nothing so that the browser does not remove the cursor
+                // from the element if its a contenteditable element.
+            }
+            else if (aChild.text == "" || bChild.text == ""){
+                // We need to redraw the parent instead of trying to replace
+                // the value of the text element, because Chrome removes
+                // this element entirely once its value is an empty string.
+                patches.push(makePatch('p-redraw', rootIndex, bParent));
+            }
+            else {
+                // Both elements have an actual text value so we'll proceed with
+                // the normal `text` patch.
+                diffHelp(aChild, bChild, patches, index);
+            }
+        }
+        else {
+            diffHelp(aChild, bChild, patches, index);
+        }
+
 		index += aChild.descendantsCount || 0;
 	}
 }


### PR DESCRIPTION
This is an attempted fix for issue https://github.com/elm-lang/virtual-dom/issues/48. It does fix the acute issue in my project but I'm not sure if this is the best way to handle the problem.

This code adds some checks on `text` virtual node types in `diffChildren` to see if either element has been set to an empty string, so that a `p-redraw` patch can be applied to the parent instead of attempting to `replaceData` on the actual `text` DOM node since it no longer exists.

**EDIT**: This only addresses the case of a contenteditable DIV containing just a plain text element, which may not even be consistent behavior between browsers. See further discussion in issue https://github.com/elm-lang/virtual-dom/issues/48.