### PR TITLE
Fix typo in mapProperty

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -280,7 +280,7 @@ function mapProperty(func, property)
 	return on(
 		property.realKey,
 		property.value.options,
-		A2(_elm_lang$core$Json$map, func, property.value.decoder)
+		A2(_elm_lang$core$Json_Decode$map, func, property.value.decoder)
 	);
 }
 


### PR DESCRIPTION
Fixes https://github.com/elm-lang/html/issues/95

`Json` should just be `Json_Decode`