### PR TITLE
add z-index to .elm-overlay

### DIFF
--- a/src/VirtualDom/Overlay.elm
+++ b/src/VirtualDom/Overlay.elm
@@ -439,6 +439,7 @@ styles =
   color: white;
   pointer-events: none;
   font-family: 'Trebuchet MS', 'Lucida Grande', 'Bitstream Vera Sans', 'Helvetica Neue', sans-serif;
+  z-index: 2147483647;
 }
 
 .elm-overlay-resume {


### PR DESCRIPTION
The debugger tab was hidden under another element in my app.

Adding z-index to `.elm-overlay` fixes it.
`2147483647` is the max value that all known browsers support.