### PR TITLE
Show title in messages.

### DIFF
--- a/src/VirtualDom/History.elm
+++ b/src/VirtualDom/History.elm
@@ -277,11 +277,14 @@ viewMessage currentIndex index msg =
 
       else
         "messages-entry"
+
+    messageName =
+      Native.Debug.messageToString msg
   in
     VDom.div
       [ VDom.class className
       , VDom.on "click" (Decode.succeed index)
       ]
-      [ VDom.span [VDom.class "messages-entry-content"] [ VDom.text (Native.Debug.messageToString msg) ]
+      [ VDom.span [VDom.class "messages-entry-content", VDom.attribute "title" messageName ] [ VDom.text messageName ]
       , VDom.span [VDom.class "messages-entry-index"] [ VDom.text (toString index) ]
       ]


### PR DESCRIPTION
This is just an update to the "add title" part of @rtfeldman's PR: https://github.com/elm-lang/virtual-dom/pull/46

this just adds the whole message name as a title to the message DOM nodes in the debugger. I've tested it out, and it appears to work well:

![screenshot 2017-01-04 13 38 13](https://cloud.githubusercontent.com/assets/1227109/21658365/8f0a150e-d283-11e6-9c09-45610a57ce2c.png)
