### PR TITLE
Fix #55, avoid crash when requestAnimationFrame is unavailable

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -1538,7 +1538,7 @@ function normalRenderer(parentNode, view)
 var rAF =
 	typeof requestAnimationFrame !== 'undefined'
 		? requestAnimationFrame
-		: function(callback) { callback(); };
+		: function(callback) { setTimeout(callback, 1000 / 60); };
 
 function makeStepper(domNode, view, initialVirtualNode, eventNode)
 {


### PR DESCRIPTION
As I understand #55, users on IE9 and certain Android devices are seeing runtime errors because `requestAnimationFrame` is not found, and the fallback is not working.

The root cause is that [`updateIfNeeded`](https://github.com/elm-lang/virtual-dom/blob/master/src/Native/VirtualDom.js#L1549-L1574) calls itself to make sure no frames are dropped. When `rAF` does not have any delay at all, this causes an infinite loop.

This PR is the minimal fix for that particular problem. It will also work with `elm-repl` which needs to run this code with `node.js`.

It may be worthwhile to do something like #74 which uses some of the old names for `requestAnimationFrame` as well, but additional testing is needed to figure out how to get them without having `window` cause crashes in `elm-repl`. That shouldn't block a fix for the crash though.

@witoldsz and others, can you confirm that this patch resolves the problem you observed?