### PR TITLE
Fix Internet Explorer invalid <input> "type" attribute runtime exception

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -186,7 +186,7 @@ function organizeFacts(factList)
 				? entry.value
 				: classes + ' ' + entry.value;
 		}
- 		else
+		else
 		{
 			facts[key] = entry.value;
 		}
@@ -536,6 +536,13 @@ function applyType(domNode, value) {
 	{
 		if (error.message === 'Invalid argument.')
 		{
+			console.warn(
+				'This browser does not support setting the `type` attribute of <'
+				+ domNode.tagName
+				+ '> to "'
+				+ value + '".\n',
+				error.stack
+			);
 			domNode.setAttribute('type', value);
 		}
 		else

--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -395,6 +395,10 @@ function applyFacts(domNode, eventNode, facts)
 				}
 				break;
 
+			case 'type':
+				applyType(domNode, key, value);
+				break;
+
 			default:
 				domNode[key] = value;
 				break;
@@ -520,6 +524,17 @@ function applyAttrsNS(domNode, nsAttrs)
 		{
 			domNode.setAttributeNS(namespace, key, value);
 		}
+	}
+}
+
+function applyType(domNode, key, value) {
+	if (value === '')
+	{
+		domNode.removeAttribute(key);
+	}
+	else
+	{
+		domNode.setAttribute(key, value);
 	}
 }
 

--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -396,7 +396,7 @@ function applyFacts(domNode, eventNode, facts)
 				break;
 
 			case 'type':
-				applyType(domNode, key, value);
+				applyType(domNode, value);
 				break;
 
 			default:
@@ -527,14 +527,21 @@ function applyAttrsNS(domNode, nsAttrs)
 	}
 }
 
-function applyType(domNode, key, value) {
-	if (value === '')
+function applyType(domNode, value) {
+	try
 	{
-		domNode.removeAttribute(key);
+		domNode.type = value;
 	}
-	else
+	catch (error)
 	{
-		domNode.setAttribute(key, value);
+		if (error.message === 'Invalid argument.')
+		{
+			domNode.setAttribute('type', value);
+		}
+		else
+		{
+			throw error;
+		}
 	}
 }
 


### PR DESCRIPTION
An attempt at addressing the <= IE11 run time exceptions first discovered in Issue #72.

### Terminology

First, a distinction between two similar terms has to be made:

1. "**Attribute**" refers to an actual `attribute` in the HTML document:
    >e.g. `<input type="text">`
    >In this instance, `type` is the attribute, its value is "text".

2. "**Property**" is a `.property` attached to a JS DOM object:
    >e.g. `imgNode.src = "https://example.com/cat.gif"`
    >`src` is the property on the `imgNode` object.

### Problem

The issue is that IE only allows a specific list of values for its `<input>` element's `type` **property**, namely values which have actual implementations backing them (e.g. radio, text, button, etc). This list increases from version to version, as the IE team implement more input types (e.g. `type="range"` is not supported in < IE9, but is supported in IE10+).

Unsupported values for `type` (e.g. `type="date"`) will cause the JS execution context to throw an exception when attempting to assign the `type` **property** (e.g. `inputElement.type = "date"`) with the exception `Invalid Argument` (even though no function is actually called...).

### Solution

This patch alleviates this problem by catching the `"Invalid argument."` error that IE throws and directly setting the DOM level `type` **attribute** using `setAttribute`, which will correctly set the `type` **attribute** AND **property** on IE (invalid values when using `setAttribute` is safely ignored as per [this comment](https://github.com/elm-lang/virtual-dom/issues/72#issuecomment-277741713) as well as empirical evidence from my own tests).

I'm retaining existing functionality in modern browsers by having `domNode.type = value` be the default `try` action, while the `catch` fallback for IE is set to use `setAttribute`.

[**Performance analysis in a follow up comment.**](https://github.com/elm-lang/virtual-dom/pull/87#issuecomment-284873682)