### PR TITLE
Add special case to `class` attribute for `Svg.Attributes.class`

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -147,7 +147,6 @@ function lazy3(fn, a, b, c)
 
 // FACTS
 
-
 function organizeFacts(factList)
 {
 	var namespace, facts = {};
@@ -160,14 +159,14 @@ function organizeFacts(factList)
 		if (key === ATTR_KEY || key === ATTR_NS_KEY || key === EVENT_KEY)
 		{
 			var subFacts = facts[key] || {};
-            if (entry.realKey === 'class') {
-                var classes = subFacts[entry.realKey];
-                subFacts[entry.realKey] = classes === undefined
-                    ? entry.value
-                    : classes + ' ' + entry.value;
-            } else {
-                subFacts[entry.realKey] = entry.value;
-            }
+			if (entry.realKey === 'class') {
+				var classes = subFacts[entry.realKey];
+				subFacts[entry.realKey] = classes === undefined
+					? entry.value
+					: classes + ' ' + entry.value;
+			} else {
+				subFacts[entry.realKey] = entry.value;
+			}
 			facts[key] = subFacts;
 		}
 		else if (key === STYLE_KEY)

--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -160,7 +160,14 @@ function organizeFacts(factList)
 		if (key === ATTR_KEY || key === ATTR_NS_KEY || key === EVENT_KEY)
 		{
 			var subFacts = facts[key] || {};
-			subFacts[entry.realKey] = entry.value;
+            if (entry.realKey === 'class') {
+                var classes = subFacts[entry.realKey];
+                subFacts[entry.realKey] = classes === undefined
+                    ? entry.value
+                    : classes + ' ' + entry.value;
+            } else {
+                subFacts[entry.realKey] = entry.value;
+            }
 			facts[key] = subFacts;
 		}
 		else if (key === STYLE_KEY)


### PR DESCRIPTION
Currently, `Html.Attributes.class` is special cased so that it can be provided multiple times, and the entries will be appended rather than overwriting one another.

It is rather surprising to the user that this behaves differently when dealing with `Svg`.

This change is slightly more complicated due to svg requiring the `class` attribute rather than a property.

Fixes #93