### PR TITLE
Use `setProperty` to apply styles rather than directly assigning

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -408,7 +408,7 @@ function applyStyles(domNode, styles)
 
 	for (var key in styles)
 	{
-		domNodeStyle[key] = styles[key];
+		domNodeStyle.setProperty(key, styles[key]);
 	}
 }
 


### PR DESCRIPTION
The current `applyStyles` implementation directly assigns to the `style` key on the domNode. CSSOM exposes an alternative method, [`setProperty`](https://www.w3.org/TR/cssom-1/#dom-cssstyledeclaration-setproperty) which behaves the same way for our intents (i.e. not setting invalid properties, removing style properties set to the empty string) while enabling one further feature we currently don't support: [custom CSS properties](https://www.w3.org/TR/css-variables/#custom-property).

Performance-wise, this changes nothing in the set of browsers I tested (Chrome, Chrome beta, Firefox, Firefox beta, IE9, IE10, IE11, IE edge, Safari, Safari Mobile, and a bunch of other mobile browsers) validating time-spent on `applyStyles` using @jinjor's vdom-dev, specifically the [`Animation.elm`](https://github.com/jinjor/vdom-dev/blob/master/src/Animation.elm) example which changes styles every `1000/60 ms`.

Closes elm-lang/html#129