### PR TITLE
use style.setProperty() to set style properties.

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -506,7 +506,7 @@ function _VirtualDom_applyStyles(domNode, styles)
 
 	for (var key in styles)
 	{
-		domNodeStyle[key] = styles[key];
+		domNodeStyle.setProperty(key, styles[key]);
 	}
 }
 


### PR DESCRIPTION
When using custom css properties the syntax `style.property = 'value'`does not work for custom css properties. 

Using `style.setProperty()` instead allows custom css properties to be used.

Fixes elm-lang/html/issues/129